### PR TITLE
Fix bug in "next post" link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 verbose = true
 
-baseURL = "http://caiustheory.com/"
+baseURL = "http://caiustheory.com"
 title = "Caius Theory"
 theme = "caiustheory"
 

--- a/themes/caiustheory/layouts/_default/list.json
+++ b/themes/caiustheory/layouts/_default/list.json
@@ -4,7 +4,7 @@
     "version" : "https://jsonfeed.org/version/1",
     "title" : "{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}",
     "description": "Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}",
-    "home_page_url" : "{{ .Site.BaseURL }}",
+    "home_page_url" : "{{ .Site.BaseURL }}/",
     {{ with .OutputFormats.Get "JSONFeed" -}}
     "feed_url" : "{{ .Permalink }}",
     {{ end -}}

--- a/themes/caiustheory/layouts/_default/single.html
+++ b/themes/caiustheory/layouts/_default/single.html
@@ -34,7 +34,10 @@
           {{- $.Scratch.Set "previous" . -}}
         {{- end -}}
         {{- if lt $.Date.Unix .Date.Unix -}}
-          {{- $.Scratch.Set "next" . -}}
+          {{- if $.Scratch.Get "next" -}}
+          {{- else -}}
+            {{- $.Scratch.Set "next" . -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
 

--- a/themes/caiustheory/layouts/partials/header.html
+++ b/themes/caiustheory/layouts/partials/header.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>{{ if .IsHome }}Latest{{ else }}{{ .Title }}{{ end }} - CaiusTheory</title>
 
-    <link rel="alternate" type="application/atom+xml" title="Caius Theory" href="{{ .Site.BaseURL }}feed.xml" />
-    <link rel="alternate" type="application/json" title="Caius Theory" href="{{ .Site.BaseURL }}feed.json" />
+    <link rel="alternate" type="application/atom+xml" title="Caius Theory" href="{{ .Site.BaseURL }}/feed.xml" />
+    <link rel="alternate" type="application/json" title="Caius Theory" href="{{ .Site.BaseURL }}/feed.json" />
 
     {{ $styles := resources.Get "css/stylesheet.css" | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $styles.Permalink }}" type="text/css" media="screen" title="no title">


### PR DESCRIPTION
We were continually overriding the scratch space when looking for the next post, which meant we ended up with the latest post rather than the _next_ post. Amend the logic for that to get the correct page. (We can't use Hugo's `.NextInSection` because none of the pages are in the same section. Nor can we use `.Next` because it pulls in non-post pages like Archive.)

Also fix an issue where we had links with `//` in their path.