### PR TITLE
Fix .text paths on Github Pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ postprocess:
 	mv public/tag/ruby1.9 public/tag/ruby19 || true
 
 	# Finally compress all the files we can to help nginx out. Do this in parallel for speeeed
-	find public -type f \( -name '*.txt' -o -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.xml' -o -name '*.svg' \) -print0 | xargs -n 10 -P 4 -0 gzip -v -k -f -9
+	find public -type f \( -name '*.txt' -o -name '*.text' -o -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.xml' -o -name '*.svg' \) -print0 | xargs -n 10 -P 4 -0 gzip -v -k -f -9
 
 .PHONY: tags
 tags:

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ postprocess:
 .PHONY: tags
 tags:
 	ruby -ryaml -e 'puts Dir["content/post/*.md"].flat_map { |path| YAML.load_file(path)["tag"] }.compact.sort.uniq'
+
+.PHONY: diff
+diff:
+	@git worktree add production gh-pages
+	make build
+	make postprocess
+	diff -r -U0 production/ public/ | grep -v -e Binary\ files -e Only  || true
+	@git worktree remove production

--- a/config.toml
+++ b/config.toml
@@ -25,20 +25,28 @@ tag = "tag"
 [permalinks]
 post = "/:slug/"
 
+[mediaTypes]
+
+  [mediaTypes."text/markdown"]
+  suffixes = ["text"]
+
 [outputFormats]
 
-# Let the magic happen for /:slug.text
-[outputFormats.PlainText]
-mediaType = "text/plain"
-isPlainText = true
+  # Let the magic happen for /:slug.text
+  [outputFormats.PlainText]
+  mediaType = "text/markdown"
+  baseName = "index"
+  isPlainText = true
+  isUgly = false
+  rel = "alternate"
 
-[outputFormats.RSSFeed]
-mediaType = "application/rss"
-baseName = "feed"
+  [outputFormats.RSSFeed]
+  mediaType = "application/rss"
+  baseName = "feed"
 
-[outputFormats.JSONFeed]
-mediaType = "application/json"
-baseName = "feed"
+  [outputFormats.JSONFeed]
+  mediaType = "application/json"
+  baseName = "feed"
 
 [outputs]
 page = ["HTML", "PlainText"]

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,10 @@ copyright = "This work is licensed under a Creative Commons Attribution-ShareAli
 
 disableKinds = ["section", "taxonomyTerm"]
 
+# Turn on Ugly URLs for everything (/slug.format)
+# We then override this for all formats except plaintext for pretty urls
+uglyurls = true
+
 PygmentsCodeFences = true
 PygmentsUseClasses = true
 pygmentsUseClassic=true
@@ -31,13 +35,15 @@ post = "/:slug/"
   suffixes = ["text"]
 
 [outputFormats]
+  [outputFormats.HTML]
+  noUgly = true
 
   # Let the magic happen for /:slug.text
   [outputFormats.PlainText]
   mediaType = "text/markdown"
   baseName = "index"
   isPlainText = true
-  isUgly = false
+  noUgly = false
   rel = "alternate"
 
   [outputFormats.RSSFeed]

--- a/themes/caiustheory/layouts/_default/single.text
+++ b/themes/caiustheory/layouts/_default/single.text
@@ -6,5 +6,4 @@
   Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-sa/4.0/>  
   {{- if .Params.reviewers -}}Many thanks to {{ delimit .Params.reviewers "," }} for proof reading. Remaining mistakes are mine alone.  {{- end -}}
 
-
 {{ .RawContent }}

--- a/themes/caiustheory/layouts/_default/single.text
+++ b/themes/caiustheory/layouts/_default/single.text
@@ -4,6 +4,6 @@
   <{{ .Permalink }}>  
   {{ .Date.Format "2006-01-02T15:04:05Z" }}  
   Licensed under the Creative Commons Attribution-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-sa/4.0/>  
-  {{- if .Params.reviewers -}}Many thanks to {{ delimit .Params.reviewers "," }} for proof reading. Remaining mistakes are mine alone.  {{- end -}}
+  {{ if .Params.reviewers -}}Many thanks to {{ delimit .Params.reviewers ", " }} for proof reading. Remaining mistakes are mine alone.  {{- end }}
 
 {{ .RawContent }}


### PR DESCRIPTION
Instead of being able to put a redirect in nginx to read from `/slug/index.txt` and have it appear at `/slug.text` we need to be able to generate `public/slug.text` as a file on disk so Github Pages can serve it correctly.

Switch around the ugly URLs, so we generate them by default. Then configure every media format except plaintext to generate non-ugly URLs (so we keep `/slug/index.html` as the canonical file for a page, appears at `/slug/` in URLs.)

Also tidy up the plaintext layout template for spacing reasons.

Also also add `make diff` to diff the currently generated branch version of the site against the deployed version (given that lives on `gh-pages`!)