### PR TITLE
Use all regular pages to generate homepage

### DIFF
--- a/themes/caiustheory/layouts/_default/list.json
+++ b/themes/caiustheory/layouts/_default/list.json
@@ -1,4 +1,4 @@
-{{ $list := .Data.Pages -}}
+{{ $list := .Site.RegularPages -}}
 {{ $length := (len $list) -}}
 {
     "version" : "https://jsonfeed.org/version/1",

--- a/themes/caiustheory/layouts/_default/list.xml
+++ b/themes/caiustheory/layouts/_default/list.xml
@@ -12,7 +12,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range .Data.Pages }}
+    {{ range .Site.RegularPages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/themes/caiustheory/layouts/partials/post-list.html
+++ b/themes/caiustheory/layouts/partials/post-list.html
@@ -1,5 +1,5 @@
 <ol>
-  {{ range (where .Data.Pages "Section" "post").GroupByDate "2006" }}
+  {{ range (where .Site.RegularPages "Section" "post").GroupByDate "2006" }}
     <li class="year">
       <h2>{{ .Key }}</h2><!-- Year heading -->
 


### PR DESCRIPTION
At some point `.Data.Pages` became `.Site.RegularPages`.

This also affects the JSON & XML feeds.