### PR TITLE
Catch people with JS disabled

### DIFF
--- a/themes/caiustheory/layouts/partials/footer.html
+++ b/themes/caiustheory/layouts/partials/footer.html
@@ -14,5 +14,8 @@
     </footer>
 
     <script data-goatcounter="https://caiustheory.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+    <noscript>
+      <img src="https://caiustheory.goatcounter.com/count?p=/test-noscript">
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
## What?

- [x] Added GoatCounter tracking pixel when JS is disabled

## Why?

Technical community tends to have more people with JS disabled, as @wjessop likes to remind me occasionally.
