### PR TITLE
URL tidy ups in template

### DIFF
--- a/themes/caiustheory/layouts/_default/list.json
+++ b/themes/caiustheory/layouts/_default/list.json
@@ -4,7 +4,7 @@
     "version" : "https://jsonfeed.org/version/1",
     "title" : "{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}",
     "description": "Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}",
-    "home_page_url" : "{{ .Site.BaseURL }}/",
+    "home_page_url" : "{{ "/" | absURL }}",
     {{ with .OutputFormats.Get "JSONFeed" -}}
     "feed_url" : "{{ .Permalink }}",
     {{ end -}}

--- a/themes/caiustheory/layouts/partials/footer.html
+++ b/themes/caiustheory/layouts/partials/footer.html
@@ -1,11 +1,11 @@
 
     <footer>
       <p class="first">
-        <a href="{{ .Site.BaseURL }}/">Archive</a>
+        <a href="{{ "/" | absURL }}">Archive</a>
         &middot;
-        <a href="{{ .Site.BaseURL }}/feed.xml">Feed (Atom)</a>
+        <a href="{{ "/feed.xml" | absURL }}">Feed (Atom)</a>
         &middot;
-        <a href="/feed.json">Feed (JSON)</a>
+        <a href="{{ "/feed.json" | absURL }}">Feed (JSON)</a>
       </p>
       <p class="last">
         Inspired by <a href="https://code.google.com/archive/p/sp-theme/">sp</a>

--- a/themes/caiustheory/layouts/partials/header.html
+++ b/themes/caiustheory/layouts/partials/header.html
@@ -7,8 +7,12 @@
 
     <link rel="canonical" href="{{ .Permalink }}">
 
-    <link rel="alternate" type="application/atom+xml" title="Caius Theory" href="{{ .Site.BaseURL }}/feed.xml" />
-    <link rel="alternate" type="application/json" title="Caius Theory" href="{{ .Site.BaseURL }}/feed.json" />
+{{ with .OutputFormats.Get "RSSFeed" -}}
+    {{ printf `    <link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
+{{ with .OutputFormats.Get "JSONFeed" -}}
+    {{ printf `    <link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 
     {{ $styles := resources.Get "css/stylesheet.css" | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $styles.Permalink }}" type="text/css" media="screen" title="no title">


### PR DESCRIPTION
- Tidyup feed links in head, remove `//`
- Tidyup feed links in footer, removing `//`
- Output absolute URLs for homepage, etc correctly throughout